### PR TITLE
Standardize worktree naming to wt-X format

### DIFF
--- a/.env.worktree
+++ b/.env.worktree
@@ -1,0 +1,3 @@
+DATABASE_NAME=meal_planner_wt4
+WORKTREE_ID=wt-4
+POOL_STATE_FILE=/tmp/pool-state.json


### PR DESCRIPTION
## Summary
- Standardizes worktree naming convention to wt-X format
- Removes dashes in database names for compatibility

## Test plan
- [ ] Verify worktree naming works correctly
- [ ] Test database connections with new naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)