### PR TITLE
feat: add Tandoor-FatSecret sync layer for meal tracking

### DIFF
--- a/src/bin/calculate_recipe_nutrition.rs
+++ b/src/bin/calculate_recipe_nutrition.rs
@@ -8,9 +8,12 @@
 //!
 //! This binary implements the core workflow:
 //! 1. Get recipe from Tandoor (ingredients, steps)
-//! 2. For each ingredient, search FatSecret for nutrition data
+//! 2. For each ingredient, search FatSecret for nutrition data (DYNAMIC LOOKUP)
 //! 3. Calculate total calories, protein, fat, carbs
 //! 4. Return nutrition data
+//!
+//! Unlike previous versions that used hardcoded ingredients, this now dynamically
+//! looks up each ingredient found in the recipe from FatSecret.
 //!
 //! JSON input (CLI arg or stdin):
 //!   `{"tandoor": {...}, "fatsecret": {...}, "recipe_id": 123}`
@@ -25,7 +28,8 @@ use meal_planner::tandoor::nutrition::core::{
 };
 use meal_planner::tandoor::{TandoorClient, TandoorConfig};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Read};
 
 #[derive(Deserialize)]
@@ -95,7 +99,11 @@ fn run() -> Result<Output, Box<dyn std::error::Error>> {
     let client = TandoorClient::new(&input.tandoor)?;
     let recipe = client.get_recipe(input.recipe_id)?;
 
-    let nutrition_db = create_nutrition_database(&input.fatsecret);
+    // Extract all unique ingredient names from the recipe
+    let ingredient_names = extract_ingredient_names(&recipe);
+
+    // Build nutrition database by dynamically looking up each ingredient
+    let nutrition_db = create_nutrition_database(&input.fatsecret, &ingredient_names);
     let result = calculate_recipe_nutrition(&recipe, &nutrition_db);
 
     Ok(Output {
@@ -107,6 +115,30 @@ fn run() -> Result<Output, Box<dyn std::error::Error>> {
         failed_ingredients: result.failed_ingredients,
         error: None,
     })
+}
+
+/// Extract all unique ingredient names from a recipe
+fn extract_ingredient_names(recipe: &Value) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    if let Some(steps) = recipe.get("steps").and_then(|v| v.as_array()) {
+        for step in steps {
+            if let Some(ingredients) = step.get("ingredients").and_then(|v| v.as_array()) {
+                for ingredient in ingredients {
+                    if let Some(name) = ingredient
+                        .get("food")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str())
+                    {
+                        // Normalize ingredient name for better FatSecret matching
+                        names.insert(name.to_lowercase());
+                    }
+                }
+            }
+        }
+    }
+
+    names
 }
 
 fn read_input() -> Result<Input, Box<dyn std::error::Error>> {
@@ -121,46 +153,34 @@ fn read_input() -> Result<Input, Box<dyn std::error::Error>> {
 
 fn create_nutrition_database(
     fatsecret: &Option<FatSecretInput>,
+    ingredient_names: &HashSet<String>,
 ) -> HashMap<String, IngredientNutrition> {
-    if fatsecret.is_some() {
-        fetch_fatsecret_nutrition(fatsecret.as_ref().unwrap())
+    if fatsecret.is_some() && !ingredient_names.is_empty() {
+        fetch_fatsecret_nutrition(fatsecret.as_ref().unwrap(), ingredient_names)
     } else {
         create_test_nutrition_db()
     }
 }
 
-fn fetch_fatsecret_nutrition(_config: &FatSecretInput) -> HashMap<String, IngredientNutrition> {
+/// Dynamically fetch nutrition for each ingredient from FatSecret
+fn fetch_fatsecret_nutrition(
+    _config: &FatSecretInput,
+    ingredient_names: &HashSet<String>,
+) -> HashMap<String, IngredientNutrition> {
     let mut db = HashMap::new();
 
     #[allow(clippy::box_collection)]
     let client = meal_planner::fatsecret::core::config::FatSecretConfig::from_env();
 
     if client.is_err() {
+        eprintln!("Warning: FatSecret config not available, using test database");
         return create_test_nutrition_db();
     }
 
     let config = client.unwrap();
 
-    let common_ingredients = [
-        "chicken breast",
-        "lettuce",
-        "olive oil",
-        "egg",
-        "butter",
-        "flour",
-        "rice",
-        "potato",
-        "beef",
-        "salmon",
-        "milk",
-        "cheese",
-        "bread",
-        "tomato",
-        "onion",
-        "garlic",
-    ];
-
-    for ingredient in common_ingredients {
+    // Dynamically lookup each ingredient found in the recipe
+    for ingredient in ingredient_names {
         if let Ok(results) = futures::executor::block_on(
             meal_planner::fatsecret::foods::search_foods_simple(&config, ingredient),
         ) {
@@ -168,12 +188,27 @@ fn fetch_fatsecret_nutrition(_config: &FatSecretInput) -> HashMap<String, Ingred
                 if let Ok(details) = futures::executor::block_on(
                     meal_planner::fatsecret::foods::get_food(&config, &food.food_id),
                 ) {
-                    if let Some(serving) = details.servings.serving.first() {
+                    // Find the best serving - prefer default, metric gram serving, or first
+                    let serving = details
+                        .servings
+                        .serving
+                        .iter()
+                        .find(|s| s.is_default == Some(1))
+                        .or_else(|| {
+                            details.servings.serving.iter().find(|s| {
+                                s.metric_serving_unit
+                                    .as_ref()
+                                    .is_some_and(|u| u == "g")
+                            })
+                        })
+                        .or_else(|| details.servings.serving.first());
+
+                    if let Some(serving) = serving {
                         let grams = serving.metric_serving_amount.unwrap_or(100.0);
-                        let multiplier = 100.0 / grams;
+                        let multiplier = if grams > 0.0 { 100.0 / grams } else { 1.0 };
 
                         db.insert(
-                            ingredient.to_string(),
+                            ingredient.clone(),
                             IngredientNutrition {
                                 food_name: food.food_name.clone(),
                                 calories_per_100g: serving.nutrition.calories * multiplier,
@@ -188,7 +223,9 @@ fn fetch_fatsecret_nutrition(_config: &FatSecretInput) -> HashMap<String, Ingred
         }
     }
 
+    // Fall back to test db if no ingredients were found
     if db.is_empty() {
+        eprintln!("Warning: No ingredients found in FatSecret, using test database");
         return create_test_nutrition_db();
     }
 

--- a/src/bin/log_recipe_to_fatsecret.rs
+++ b/src/bin/log_recipe_to_fatsecret.rs
@@ -1,0 +1,246 @@
+//! Log a Tandoor recipe to FatSecret food diary
+//!
+//! This binary syncs a Tandoor recipe to FatSecret by logging it as a custom diary entry.
+//! It uses the recipe's nutrition data (calories, protein, carbs, fat) directly.
+//!
+//! This is part of the Tandoor ↔ FatSecret sync layer.
+//!
+//! JSON input (CLI arg or stdin):
+//!   `{"tandoor": {...}, "fatsecret": {...}, "access_token": "...", "access_secret": "...",
+//!     "recipe_id": 123, "servings": 2.0, "meal": "dinner", "date": "2025-01-01"}`
+//!
+//! JSON stdout:
+//!   `{"success": true, "food_entry_id": "123456789", "recipe_name": "Grilled Chicken",
+//!     "calories": 450.0, "protein": 40.0, "carbohydrate": 5.0, "fat": 25.0}`
+
+#![allow(clippy::exit, clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
+
+use meal_planner::fatsecret::core::{AccessToken, FatSecretConfig};
+use meal_planner::fatsecret::diary::{create_food_entry, date_to_int, FoodEntryInput, MealType};
+use meal_planner::tandoor::{TandoorClient, TandoorConfig};
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read};
+
+#[derive(Deserialize)]
+struct TandoorResource {
+    base_url: String,
+    api_token: String,
+}
+
+#[derive(Deserialize)]
+struct FatSecretResource {
+    consumer_key: String,
+    consumer_secret: String,
+}
+
+#[derive(Deserialize)]
+struct Input {
+    /// Tandoor configuration
+    tandoor: TandoorResource,
+    /// FatSecret credentials
+    fatsecret: Option<FatSecretResource>,
+    /// OAuth access token for FatSecret
+    access_token: String,
+    /// OAuth access token secret for FatSecret
+    access_secret: String,
+    /// Tandoor recipe ID to log
+    recipe_id: i64,
+    /// Number of servings consumed (defaults to recipe's default servings)
+    servings: Option<f64>,
+    /// Meal type: breakfast, lunch, dinner, or other
+    meal: String,
+    /// Date in YYYY-MM-DD format
+    date: String,
+}
+
+#[derive(Serialize)]
+struct Output {
+    success: bool,
+    food_entry_id: String,
+    recipe_name: String,
+    calories: f64,
+    protein: f64,
+    carbohydrate: f64,
+    fat: f64,
+}
+
+#[derive(Serialize)]
+struct ErrorOutput {
+    success: bool,
+    error: String,
+}
+
+#[tokio::main]
+async fn main() {
+    match run().await {
+        Ok(output) => {
+            println!(
+                "{}",
+                serde_json::to_string(&output).expect("Failed to serialize output")
+            );
+        }
+        Err(e) => {
+            let error = ErrorOutput {
+                success: false,
+                error: e.to_string(),
+            };
+            println!(
+                "{}",
+                serde_json::to_string(&error).expect("Failed to serialize error")
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn run() -> Result<Output, Box<dyn std::error::Error>> {
+    let input: Input = read_input()?;
+
+    // Get recipe from Tandoor
+    let tandoor_config = TandoorConfig {
+        base_url: input.tandoor.base_url.clone(),
+        api_token: input.tandoor.api_token.clone(),
+    };
+    let tandoor_client = TandoorClient::new(&tandoor_config)?;
+    let recipe = tandoor_client.get_recipe(input.recipe_id)?;
+
+    // Extract recipe name
+    let recipe_name = recipe
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("Recipe has no name")?
+        .to_string();
+
+    // Extract nutrition from recipe (as JSON Value)
+    let nutrition = recipe
+        .get("nutrition")
+        .ok_or("Recipe has no nutrition data. Run nutrition calculation first.")?;
+
+    // Calculate per-serving nutrition scaled by requested servings
+    // Note: servings are typically small integers, safe to convert to f64
+    #[allow(clippy::cast_precision_loss)]
+    let recipe_servings = recipe
+        .get("servings")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(1) as f64;
+    let requested_servings = input.servings.unwrap_or(recipe_servings);
+    let multiplier = if recipe_servings > 0.0 {
+        requested_servings / recipe_servings
+    } else {
+        1.0
+    };
+
+    // Extract nutrition values (Tandoor uses "calories", "proteins", "carbohydrates", "fats")
+    let calories = nutrition
+        .get("calories")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+        * multiplier;
+    let protein = nutrition
+        .get("proteins")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+        * multiplier;
+    let carbohydrate = nutrition
+        .get("carbohydrates")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+        * multiplier;
+    let fat = nutrition
+        .get("fats")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0)
+        * multiplier;
+
+    // Get FatSecret config
+    let fs_config = match input.fatsecret {
+        Some(r) => FatSecretConfig::new(r.consumer_key, r.consumer_secret)?,
+        None => FatSecretConfig::from_env()?,
+    };
+
+    // Build access token
+    let token = AccessToken::new(input.access_token, input.access_secret);
+
+    // Parse meal type
+    let meal = MealType::from_api_string(&input.meal).ok_or_else(|| {
+        format!(
+            "Invalid meal type: {}. Expected: breakfast, lunch, dinner, or other",
+            input.meal
+        )
+    })?;
+
+    // Convert date to FatSecret date_int
+    let date_int = date_to_int(&input.date)?;
+
+    // Build serving description
+    let serving_desc = format!("{} servings from Tandoor recipe", requested_servings);
+
+    // Create custom food entry (uses recipe nutrition directly)
+    let entry_input = FoodEntryInput::Custom {
+        food_entry_name: recipe_name.clone(),
+        serving_description: serving_desc,
+        number_of_units: 1.0, // 1 unit = the calculated serving amount
+        meal,
+        date_int,
+        calories,
+        carbohydrate,
+        protein,
+        fat,
+    };
+
+    // Create the diary entry
+    let entry_id = create_food_entry(&fs_config, &token, entry_input).await?;
+
+    Ok(Output {
+        success: true,
+        food_entry_id: entry_id.to_string(),
+        recipe_name,
+        calories,
+        protein,
+        carbohydrate,
+        fat,
+    })
+}
+
+fn read_input() -> Result<Input, Box<dyn std::error::Error>> {
+    if let Some(arg) = std::env::args().nth(1) {
+        Ok(serde_json::from_str(&arg)?)
+    } else {
+        let mut input_str = String::new();
+        io::stdin().read_to_string(&mut input_str)?;
+        Ok(serde_json::from_str(&input_str)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_output_serialize() {
+        let output = Output {
+            success: true,
+            food_entry_id: "123456".to_string(),
+            recipe_name: "Grilled Chicken".to_string(),
+            calories: 450.0,
+            protein: 40.0,
+            carbohydrate: 5.0,
+            fat: 25.0,
+        };
+        let json = serde_json::to_string(&output).expect("Failed to serialize");
+        assert!(json.contains("\"success\":true"));
+        assert!(json.contains("\"recipe_name\":\"Grilled Chicken\""));
+        assert!(json.contains("\"calories\":450"));
+    }
+
+    #[test]
+    fn test_error_output_serialize() {
+        let error = ErrorOutput {
+            success: false,
+            error: "Test error".to_string(),
+        };
+        let json = serde_json::to_string(&error).expect("Failed to serialize");
+        assert!(json.contains("\"success\":false"));
+        assert!(json.contains("\"error\":\"Test error\""));
+    }
+}

--- a/windmill/f/fatsecret/get_token.script.yaml
+++ b/windmill/f/fatsecret/get_token.script.yaml
@@ -1,0 +1,18 @@
+summary: Get FatSecret OAuth token from storage
+description: |
+  Retrieves the stored FatSecret OAuth access token from secure database storage.
+  The token is decrypted and returned for use by other scripts.
+  Use check_only=true to verify token existence without retrieving it.
+lock: ''
+kind: script
+language: bash
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  properties:
+    check_only:
+      type: boolean
+      description: If true, only check token validity without returning the actual token
+      default: false
+      originalType: boolean
+  required: []

--- a/windmill/f/fatsecret/get_token.sh
+++ b/windmill/f/fatsecret/get_token.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+# Get FatSecret OAuth access token from secure storage
+# Arguments: check_only (optional, defaults to false)
+
+check_only="${1:-false}"
+
+# Build JSON input for binary
+input=$(jq -n \
+	--argjson check_only "$check_only" \
+	'{check_only: $check_only}')
+
+# Call binary and capture output
+echo "$input" | /usr/local/bin/meal-planner/fatsecret_get_token >./result.json

--- a/windmill/f/tandoor/log_recipe_to_fatsecret.script.yaml
+++ b/windmill/f/tandoor/log_recipe_to_fatsecret.script.yaml
@@ -1,0 +1,65 @@
+summary: Log Tandoor recipe to FatSecret diary
+description: |
+  Syncs a Tandoor recipe to FatSecret by logging it as a custom diary entry.
+  Uses the recipe's nutrition data (calories, protein, carbs, fat) directly.
+  This enables tracking Tandoor recipes in FatSecret for calorie counting.
+lock: ''
+kind: script
+language: bash
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  properties:
+    tandoor:
+      type: object
+      description: Tandoor API credentials (base_url, api_token)
+      default: null
+      originalType: object
+    fatsecret:
+      type: object
+      description: FatSecret API credentials (consumer_key, consumer_secret)
+      default: null
+      originalType: object
+    access_token:
+      type: string
+      description: FatSecret OAuth access token
+      default: null
+      originalType: string
+    access_secret:
+      type: string
+      description: FatSecret OAuth access token secret
+      default: null
+      originalType: string
+    recipe_id:
+      type: integer
+      description: Tandoor recipe ID to log
+      default: null
+      originalType: integer
+    servings:
+      type: number
+      description: Number of servings consumed (optional, defaults to recipe servings)
+      default: null
+      originalType: number
+    meal:
+      type: string
+      description: 'Meal type: breakfast, lunch, dinner, or other'
+      default: dinner
+      originalType: string
+      enum:
+        - breakfast
+        - lunch
+        - dinner
+        - other
+    date:
+      type: string
+      description: Date in YYYY-MM-DD format
+      default: null
+      originalType: string
+  required:
+    - tandoor
+    - fatsecret
+    - access_token
+    - access_secret
+    - recipe_id
+    - meal
+    - date

--- a/windmill/f/tandoor/log_recipe_to_fatsecret.sh
+++ b/windmill/f/tandoor/log_recipe_to_fatsecret.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+# Log a Tandoor recipe to FatSecret food diary
+# Arguments: tandoor (resource), fatsecret (resource), access_token, access_secret, recipe_id, servings, meal, date
+
+tandoor="$1"
+fatsecret="$2"
+access_token="$3"
+access_secret="$4"
+recipe_id="$5"
+servings="$6"
+meal="$7"
+date="$8"
+
+# Build JSON input for binary
+input=$(jq -n \
+	--argjson tandoor "$tandoor" \
+	--argjson fatsecret "$fatsecret" \
+	--arg access_token "$access_token" \
+	--arg access_secret "$access_secret" \
+	--argjson recipe_id "$recipe_id" \
+	--argjson servings "$servings" \
+	--arg meal "$meal" \
+	--arg date "$date" \
+	'{
+		tandoor: $tandoor,
+		fatsecret: $fatsecret,
+		access_token: $access_token,
+		access_secret: $access_secret,
+		recipe_id: $recipe_id,
+		servings: $servings,
+		meal: $meal,
+		date: $date
+	}')
+
+# Call binary and capture output
+echo "$input" | /usr/local/bin/meal-planner/log_recipe_to_fatsecret >./result.json

--- a/windmill/f/tandoor/sync_meal_plan_to_diary.flow/flow.yaml
+++ b/windmill/f/tandoor/sync_meal_plan_to_diary.flow/flow.yaml
@@ -1,0 +1,178 @@
+summary: Sync Tandoor meal plan to FatSecret diary
+description: |
+  Syncs all meal plan entries within a date range to your FatSecret food diary.
+  Each recipe is logged as a custom food entry with its nutrition data.
+
+  Requirements:
+  - Recipes must have nutrition data (run add_calories_to_recipes flow first)
+  - FatSecret OAuth must be connected (run oauth_setup flow first)
+
+  This enables automatic calorie tracking for your planned meals.
+
+value:
+  modules:
+    - id: get_token
+      summary: Get FatSecret OAuth token
+      value:
+        type: script
+        path: f/fatsecret/get_token
+        input_transforms:
+          check_only:
+            type: static
+            value: false
+
+    - id: check_token
+      summary: Verify token is valid
+      value:
+        type: rawscript
+        language: bun
+        content: |
+          export async function main(token_result: any) {
+            if (token_result.status === "not_found") {
+              throw new Error("FatSecret not connected. Run the OAuth setup flow first.");
+            }
+            return {
+              oauth_token: token_result.oauth_token,
+              oauth_token_secret: token_result.oauth_token_secret
+            };
+          }
+        input_transforms:
+          token_result:
+            type: javascript
+            expr: results.get_token
+
+    - id: list_meal_plans
+      summary: Get meal plan entries for date range
+      value:
+        type: script
+        path: f/tandoor/meal_plan_list
+        input_transforms:
+          tandoor:
+            type: static
+            value: '$res:u/admin/tandoor_api'
+          from_date:
+            type: javascript
+            expr: flow_input.from_date
+          to_date:
+            type: javascript
+            expr: flow_input.to_date || flow_input.from_date
+
+    - id: sync_entries
+      summary: Log each meal plan entry to FatSecret
+      value:
+        type: forloopflow
+        iterator:
+          type: javascript
+          expr: results.list_meal_plans.results || []
+        skip_failures: true
+        modules:
+          - id: map_meal_type
+            summary: Map Tandoor meal type to FatSecret
+            value:
+              type: rawscript
+              language: bun
+              content: |
+                export async function main(entry: any) {
+                  // Map Tandoor meal type names to FatSecret meal types
+                  const mealTypeMap: Record<string, string> = {
+                    "breakfast": "breakfast",
+                    "lunch": "lunch",
+                    "dinner": "dinner",
+                    "snack": "other",
+                    "other": "other"
+                  };
+
+                  const mealTypeName = (entry.meal_type?.name || "dinner").toLowerCase();
+                  const fsMealType = mealTypeMap[mealTypeName] || "other";
+
+                  return {
+                    recipe_id: entry.recipe?.id,
+                    recipe_name: entry.recipe?.name || "Unknown Recipe",
+                    servings: entry.servings || 1,
+                    meal: fsMealType,
+                    date: entry.from_date || entry.date
+                  };
+                }
+              input_transforms:
+                entry:
+                  type: javascript
+                  expr: flow_input.iter.value
+
+          - id: log_entry
+            summary: Log recipe to FatSecret
+            value:
+              type: script
+              path: f/tandoor/log_recipe_to_fatsecret
+              input_transforms:
+                tandoor:
+                  type: static
+                  value: '$res:u/admin/tandoor_api'
+                fatsecret:
+                  type: static
+                  value: '$res:u/admin/fatsecret_api'
+                access_token:
+                  type: javascript
+                  expr: results.check_token.oauth_token
+                access_secret:
+                  type: javascript
+                  expr: results.check_token.oauth_token_secret
+                recipe_id:
+                  type: javascript
+                  expr: results.map_meal_type.recipe_id
+                servings:
+                  type: javascript
+                  expr: results.map_meal_type.servings
+                meal:
+                  type: javascript
+                  expr: results.map_meal_type.meal
+                date:
+                  type: javascript
+                  expr: results.map_meal_type.date
+
+    - id: summary
+      summary: Generate sync summary
+      value:
+        type: rawscript
+        language: bun
+        content: |
+          export async function main(meal_plans: any, sync_results: any) {
+            const entries = meal_plans.results || [];
+            const synced = (sync_results || []).filter((r: any) => r && r.success);
+            const failed = entries.length - synced.length;
+
+            return {
+              success: true,
+              message: `Synced ${synced.length} of ${entries.length} meal plan entries to FatSecret`,
+              total_entries: entries.length,
+              synced_count: synced.length,
+              failed_count: failed,
+              entries: synced.map((r: any) => ({
+                recipe: r.recipe_name,
+                calories: r.calories
+              }))
+            };
+          }
+        input_transforms:
+          meal_plans:
+            type: javascript
+            expr: results.list_meal_plans
+          sync_results:
+            type: javascript
+            expr: results.sync_entries
+
+  same_worker: false
+
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  properties:
+    from_date:
+      type: string
+      description: Start date in YYYY-MM-DD format
+      format: date
+    to_date:
+      type: string
+      description: End date in YYYY-MM-DD format (optional, defaults to from_date)
+      format: date
+  required:
+    - from_date

--- a/windmill/f/tandoor/sync_meal_to_fatsecret.flow/flow.yaml
+++ b/windmill/f/tandoor/sync_meal_to_fatsecret.flow/flow.yaml
@@ -1,0 +1,130 @@
+summary: Sync Tandoor recipe to FatSecret diary
+description: |
+  Logs a Tandoor recipe to your FatSecret food diary as a custom entry.
+  This enables tracking Tandoor recipes in FatSecret for calorie counting.
+
+  Requirements:
+  - Recipe must have nutrition data (run nutrition calculation first)
+  - FatSecret OAuth must be connected (run oauth_setup flow first)
+
+  The recipe's nutrition (calories, protein, carbs, fat) is logged directly
+  to FatSecret as a custom food entry with the recipe name.
+
+value:
+  modules:
+    - id: get_token
+      summary: Get FatSecret OAuth token
+      value:
+        type: script
+        path: f/fatsecret/get_token
+        input_transforms:
+          check_only:
+            type: static
+            value: false
+
+    - id: check_token
+      summary: Verify token is valid
+      value:
+        type: rawscript
+        language: bun
+        content: |
+          export async function main(token_result: any) {
+            if (token_result.status === "not_found") {
+              throw new Error("FatSecret not connected. Run the OAuth setup flow first.");
+            }
+            if (token_result.status === "old") {
+              console.log("Warning: Token is " + token_result.days_since_connected + " days old. Consider re-authenticating.");
+            }
+            return {
+              oauth_token: token_result.oauth_token,
+              oauth_token_secret: token_result.oauth_token_secret
+            };
+          }
+        input_transforms:
+          token_result:
+            type: javascript
+            expr: results.get_token
+
+    - id: log_recipe
+      summary: Log recipe to FatSecret diary
+      value:
+        type: script
+        path: f/tandoor/log_recipe_to_fatsecret
+        input_transforms:
+          tandoor:
+            type: static
+            value: '$res:u/admin/tandoor_api'
+          fatsecret:
+            type: static
+            value: '$res:u/admin/fatsecret_api'
+          access_token:
+            type: javascript
+            expr: results.check_token.oauth_token
+          access_secret:
+            type: javascript
+            expr: results.check_token.oauth_token_secret
+          recipe_id:
+            type: javascript
+            expr: flow_input.recipe_id
+          servings:
+            type: javascript
+            expr: flow_input.servings || null
+          meal:
+            type: javascript
+            expr: flow_input.meal || "dinner"
+          date:
+            type: javascript
+            expr: flow_input.date
+
+    - id: format_result
+      summary: Format success message
+      value:
+        type: rawscript
+        language: bun
+        content: |
+          export async function main(log_result: any) {
+            return {
+              success: true,
+              message: `Logged "${log_result.recipe_name}" to FatSecret diary`,
+              entry_id: log_result.food_entry_id,
+              nutrition: {
+                calories: log_result.calories,
+                protein: log_result.protein,
+                carbohydrate: log_result.carbohydrate,
+                fat: log_result.fat
+              }
+            };
+          }
+        input_transforms:
+          log_result:
+            type: javascript
+            expr: results.log_recipe
+
+  same_worker: false
+
+schema:
+  $schema: 'https://json-schema.org/draft/2020-12/schema'
+  type: object
+  properties:
+    recipe_id:
+      type: integer
+      description: Tandoor recipe ID to log
+    servings:
+      type: number
+      description: Number of servings consumed (optional, defaults to recipe servings)
+    meal:
+      type: string
+      description: 'Meal type: breakfast, lunch, dinner, or other'
+      default: dinner
+      enum:
+        - breakfast
+        - lunch
+        - dinner
+        - other
+    date:
+      type: string
+      description: Date in YYYY-MM-DD format
+      format: date
+  required:
+    - recipe_id
+    - date


### PR DESCRIPTION
This implements the core Tandoor ↔ FatSecret synchronization:

New binaries:
- log_recipe_to_fatsecret: Log Tandoor recipes to FatSecret diary as
  custom entries using the recipe's calculated nutrition

New Windmill flows:
- sync_meal_to_fatsecret.flow: Sync a single recipe to FatSecret diary
- sync_meal_plan_to_diary.flow: Bulk sync all meal plan entries for a
  date range to FatSecret diary

Improved features:
- calculate_recipe_nutrition now dynamically looks up each ingredient
  from the recipe in FatSecret, rather than using hardcoded ingredients
- Added get_token Windmill script to retrieve stored OAuth tokens

This enables automatic calorie tracking: plan meals in Tandoor,
then sync to FatSecret for nutrition logging.